### PR TITLE
Bug fix: Scan argv-provided directories

### DIFF
--- a/src/main/java/com/vaguehope/dlnatoad/Args.java
+++ b/src/main/java/com/vaguehope/dlnatoad/Args.java
@@ -38,7 +38,7 @@ public class Args {
 		if (this.dirPaths != null && this.dirPaths.size() > 0) {
 			final List<File> cliDirs = pathsToFiles(this.dirPaths);
 			checkDirExist(cliDirs);
-			dirs.addAll(dirs);
+			dirs.addAll(cliDirs);
 		}
 
 		if (dirs.size() < 1) dirs.add(new File("."));


### PR DESCRIPTION
Looks like a minor typo. Neat project btw. :)

## Steps to reproduce
1. Put a bunch of movies in `~/Movies`
2. Execute `java -jar dlnatoad.jar ~/Movies` in a directory other than `~/Movies`

## Expected
dlnatoad serves `~/Movies`

## Actual
dlnatoad serves `.`